### PR TITLE
Bugfix in download Thingi10k

### DIFF
--- a/examples/SubTriangulation.jl
+++ b/examples/SubTriangulation.jl
@@ -11,6 +11,7 @@ function download(id;path="")
   r = Downloads.request(url)
   if 200 ≤ r.status ≤ 399
     _,ext = splitext(r.url)
+    ext, = split(ext,'?')
     mkpath(path)
     filename = joinpath(path,"$id$ext")
     Downloads.download(url,filename)

--- a/test/SampleGeometriesTests.jl
+++ b/test/SampleGeometriesTests.jl
@@ -16,6 +16,7 @@ function download(id;path="")
   r = Downloads.request(url)
   if 200 ≤ r.status ≤ 399
     _,ext = splitext(r.url)
+    ext, = split(ext,'?')
     mkpath(path)
     filename = joinpath(path,"$id$ext")
     Downloads.download(url,filename)


### PR DESCRIPTION
The Thingi10k download URL now has the following format 

`.$(EXTENSION)?*`

The `download()` procedure in examples is changed accordingly.