### PR TITLE
Update MeshIO compat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-04-10
+
+### Added
+
+- Added support for MeshIO v0.5
+
 ## [0.3.2] - 2026-03-29
 
 ### Added
@@ -53,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cut()` interface has been changed to align with `GridapEmbeded`.
 - `subtriangulate()` also returns cut facet data.
 - The output order of _simplexify_ functions has changed: (1st) coordinates, (2nd) connectivities.
-  
+
 ### Removed
 
 - `plot(::Polyhedron)` is removed to reduce dependencies [#28](https://github.com/gridap/STLCutters.jl/pull/28).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "STLCutters"
 uuid = "284f087d-c8bb-44c4-af3c-39d0e1f330a5"
 authors = ["Pere Antoni Martorell", "Large Scale Scientific Computing"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
@@ -29,7 +29,7 @@ GridapDistributed = "0.4"
 GridapEmbedded = "0.9.4"
 IterativeSolvers = "0.9"
 MPI = "0.20"
-MeshIO = "0.4"
+MeshIO = "0.5"
 MiniQhull = "0.4"
 PartitionedArrays = "0.3"
 ProgressMeter = "1.7"

--- a/src/STLs.jl
+++ b/src/STLs.jl
@@ -249,7 +249,7 @@ function save_as_stl(stl::DiscreteModel{Dc,Dp},filename) where {Dc,Dp}
     vertices[ (i-1)*3+2 ] = pointtype(Tuple(coords[2])...)
     vertices[ (i-1)*3+3 ] = pointtype(Tuple(coords[3])...)
   end
-  mesh = MeshIO.Mesh(MeshIO.meta(vertices; normals=normals), faces)
+  mesh = MeshIO.Mesh(vertices, faces; normals=normals)
   save(file,mesh)
   filename
 end


### PR DESCRIPTION
This PR is to update the MeshIO compat from v0.4 to v0.5. This avoids version conflicts of MeshIO with GridapMakie/Makie.